### PR TITLE
Fix paint buffer dimensions

### DIFF
--- a/src/display.cpp
+++ b/src/display.cpp
@@ -11,8 +11,8 @@
 #define COLORED 0
 #define UNCOLORED 1
 
-static unsigned char image[1024];
-static Paint paint(image, 0, 0);
+static unsigned char image[128 * 24 / 8];
+static Paint paint(image, 128, 24);
 static Epd epd;
 
 void displaySetup() {
@@ -24,8 +24,6 @@ void displaySetup() {
     epd.ClearFrameMemory(0xFF);
     epd.DisplayFrame();
     paint.SetRotate(ROTATE_0);
-    paint.SetWidth(128);
-    paint.SetHeight(24);
 }
 
 void displayValues(float temperature, double pressure) {


### PR DESCRIPTION
## Summary
- size the display image buffer to the actual 128x24 drawing window
- construct the Paint instance with the real dimensions and drop redundant setters

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68ca9c207e6c832fa1a51f2c3bcea5e3