### PR TITLE
Configure potentiometer gradient mapping

### DIFF
--- a/src/potentiometer.cpp
+++ b/src/potentiometer.cpp
@@ -6,14 +6,42 @@
 #include "potentiometer.h"
 #include <Arduino.h>
 
-static int potPin = 0;
+namespace {
+struct PotentiometerConfig {
+    float minGradientCPerS;
+    float maxGradientCPerS;
+    uint8_t smoothingSamples;
+};
 
-void potentiometerSetup(int pin) {
+static PotentiometerConfig config = {0.01f, 0.30f, 8};
+static int potPin = 0;
+}
+
+void potentiometerSetup(int pin, PotentiometerScale scale, uint8_t smoothingSamples) {
     potPin = pin;
+
+    if (scale.maxGradientCPerS < scale.minGradientCPerS) {
+        float temp = scale.maxGradientCPerS;
+        scale.maxGradientCPerS = scale.minGradientCPerS;
+        scale.minGradientCPerS = temp;
+    }
+
+    config.minGradientCPerS = scale.minGradientCPerS;
+    config.maxGradientCPerS = scale.maxGradientCPerS;
+    config.smoothingSamples = smoothingSamples == 0 ? 1 : smoothingSamples;
+
     pinMode(potPin, INPUT);
 }
 
 float readPotentiometer() {
-    float pot = analogRead(potPin) / 100.0f;
-    return pot / 10.0f + 0.6f;
+    uint32_t total = 0;
+    for (uint8_t i = 0; i < config.smoothingSamples; ++i) {
+        total += static_cast<uint32_t>(analogRead(potPin));
+    }
+
+    float averageReading = static_cast<float>(total) / config.smoothingSamples;
+    float normalized = constrain(averageReading / 1023.0f, 0.0f, 1.0f);
+
+    float range = config.maxGradientCPerS - config.minGradientCPerS;
+    return config.minGradientCPerS + normalized * range;
 }

--- a/src/potentiometer.h
+++ b/src/potentiometer.h
@@ -1,11 +1,28 @@
 /**
  * @file potentiometer.h
- * @brief Provides sensitivity threshold from a potentiometer.
+ * @brief Provides a configurable gradient threshold from a potentiometer.
  *
  * This module reads an analog pin connected to a potentiometer to determine
- * the user-defined threshold for buzzer activation.
+ * a user-defined gradient threshold (e.g. 0.01–0.30 °C/s after adiabatic
+ * compensation). The raw ADC value is mapped onto the configured scale and
+ * optionally averaged across several samples for improved stability in flight.
  */
 #pragma once
 
-void potentiometerSetup(int pin);
+#include <stdint.h>
+
+/**
+ * @brief Describes the gradient range covered by the potentiometer.
+ */
+struct PotentiometerScale {
+    float minGradientCPerS; /**< Threshold corresponding to the minimum ADC value. */
+    float maxGradientCPerS; /**< Threshold corresponding to the maximum ADC value. */
+};
+
+void potentiometerSetup(int pin,
+                        PotentiometerScale scale = {0.01f, 0.30f},
+                        uint8_t smoothingSamples = 8);
+/**
+ * @brief Returns the configured gradient threshold in °C/s.
+ */
 float readPotentiometer();


### PR DESCRIPTION
## Summary
- add a configurable ADC-to-gradient mapping with optional averaging for the potentiometer
- configure the sketch to use the gradient scale and convert the setting into the filter threshold delta

## Testing
- not run (Arduino project without automated tests)


------
https://chatgpt.com/codex/tasks/task_e_68caa31d317c832fa24f4ae92999e9ca