### PR TITLE
Implement non-blocking thermal filtering for buzzer

### DIFF
--- a/Thermal-sniffer V1.0.ino
+++ b/Thermal-sniffer V1.0.ino
@@ -16,13 +16,108 @@ void setup() {
 }
 
 void loop() {
+  const unsigned long SAMPLE_INTERVAL_MS = 150;
+  const unsigned long WINDOW_DURATION_MS = 5000;
+  const float GROUND_SPEED_MPS = 11.11f; // ~40 km/h
+  const size_t MAX_WINDOW_SAMPLES = WINDOW_DURATION_MS / SAMPLE_INTERVAL_MS + 4;
+
+  static unsigned long lastSampleTime = 0;
+  unsigned long now = millis();
+  if (lastSampleTime != 0 && now - lastSampleTime < SAMPLE_INTERVAL_MS) {
+    return;
+  }
+  lastSampleTime = now;
+
   float temperature = readTemperatureC();
   double pressure = readPressure();
-  static float lastTemp = temperature;
-  float diff = temperature - lastTemp;
-  lastTemp = temperature;
+
+  static float temperatureHistory[MAX_WINDOW_SAMPLES];
+  static double pressureHistory[MAX_WINDOW_SAMPLES];
+  static unsigned long timestampHistory[MAX_WINDOW_SAMPLES];
+  static size_t windowStart = 0;
+  static size_t windowEnd = 0;
+  static size_t windowCount = 0;
+
+  temperatureHistory[windowEnd] = temperature;
+  pressureHistory[windowEnd] = pressure;
+  timestampHistory[windowEnd] = now;
+  windowEnd = (windowEnd + 1) % MAX_WINDOW_SAMPLES;
+  if (windowCount < MAX_WINDOW_SAMPLES) {
+    ++windowCount;
+  } else {
+    windowStart = (windowStart + 1) % MAX_WINDOW_SAMPLES;
+  }
+
+  while (windowCount > 0) {
+    unsigned long oldestTime = timestampHistory[windowStart];
+    if (now - oldestTime <= WINDOW_DURATION_MS) {
+      break;
+    }
+    windowStart = (windowStart + 1) % MAX_WINDOW_SAMPLES;
+    --windowCount;
+  }
+
+  float tempSlopeSum = 0.0f;
+  float tempSlopeSqSum = 0.0f;
+  float pressureSlopeSum = 0.0f;
+  float pressureSlopeSqSum = 0.0f;
+  size_t slopeCount = 0;
+
+  if (windowCount > 1) {
+    for (size_t i = 0; i < windowCount - 1; ++i) {
+      size_t idxCurrent = (windowStart + i) % MAX_WINDOW_SAMPLES;
+      size_t idxNext = (windowStart + i + 1) % MAX_WINDOW_SAMPLES;
+      unsigned long dtMs = timestampHistory[idxNext] - timestampHistory[idxCurrent];
+      if (dtMs == 0) {
+        continue;
+      }
+      float dtSeconds = static_cast<float>(dtMs) / 1000.0f;
+      float tempSlopePerMeter = ((temperatureHistory[idxNext] - temperatureHistory[idxCurrent]) / dtSeconds) / GROUND_SPEED_MPS;
+      float pressureSlopePerMeter = ((pressureHistory[idxNext] - pressureHistory[idxCurrent]) / dtSeconds) / GROUND_SPEED_MPS;
+
+      tempSlopeSum += tempSlopePerMeter;
+      tempSlopeSqSum += tempSlopePerMeter * tempSlopePerMeter;
+      pressureSlopeSum += pressureSlopePerMeter;
+      pressureSlopeSqSum += pressureSlopePerMeter * pressureSlopePerMeter;
+      ++slopeCount;
+    }
+  }
+
+  float filteredSignal = 0.0f;
+  if (slopeCount > 0) {
+    float meanTempSlope = tempSlopeSum / slopeCount;
+    float meanPressureSlope = pressureSlopeSum / slopeCount;
+
+    float tempVariance = tempSlopeSqSum / slopeCount - meanTempSlope * meanTempSlope;
+    tempVariance = tempVariance < 0.0f ? 0.0f : tempVariance;
+    float tempStd = sqrtf(tempVariance);
+
+    float pressureVariance = pressureSlopeSqSum / slopeCount - meanPressureSlope * meanPressureSlope;
+    pressureVariance = pressureVariance < 0.0f ? 0.0f : pressureVariance;
+    float pressureStd = sqrtf(pressureVariance);
+
+    float coherentTemp = 0.0f;
+    if (meanTempSlope > 0.0f) {
+      coherentTemp = meanTempSlope - tempStd;
+      if (coherentTemp < 0.0f) {
+        coherentTemp = 0.0f;
+      }
+    }
+
+    float coherentPressure = 0.0f;
+    float pressureDrop = -meanPressureSlope;
+    if (pressureDrop > 0.0f) {
+      coherentPressure = pressureDrop - pressureStd;
+      if (coherentPressure < 0.0f) {
+        coherentPressure = 0.0f;
+      }
+    }
+
+    filteredSignal = (coherentTemp + coherentPressure) * 100.0f;
+  }
+
   float threshold = readPotentiometer();
-  buzzerUpdate(diff, threshold);
+  buzzerUpdate(filteredSignal, threshold);
 
   static float lastDisplayedTemp = NAN;
   static double lastDisplayedPressure = NAN;
@@ -31,7 +126,6 @@ void loop() {
   const double PRESSURE_TOLERANCE = 0.5;
   const unsigned long DISPLAY_TIMEOUT_MS = 10000;
 
-  unsigned long now = millis();
   bool firstUpdate = isnan(lastDisplayedTemp) || isnan(lastDisplayedPressure);
   bool tempChanged = firstUpdate || fabsf(temperature - lastDisplayedTemp) > TEMP_TOLERANCE;
   bool pressureChanged = firstUpdate || fabs(pressure - lastDisplayedPressure) > PRESSURE_TOLERANCE;
@@ -43,6 +137,4 @@ void loop() {
     lastDisplayedPressure = pressure;
     lastDisplayUpdate = now;
   }
-
-  delay(1000);
 }

--- a/src/buzzer.cpp
+++ b/src/buzzer.cpp
@@ -12,15 +12,41 @@ static const float pitch = 1.059463119f;
 
 void buzzerSetup() {}
 
-void buzzerUpdate(float tempDiff, float threshold) {
-    if (fabs(tempDiff) > threshold) {
-        int variaNote = abs(tempDiff) * 5;
-        float tonal = tonalBase;
-        if (tempDiff > 0) {
-            tonal *= pow(pitch, variaNote);
-        } else {
-            tonal /= pow(pitch, variaNote);
-        }
-        tone(6, tonal, 1000);
+void buzzerUpdate(float filteredSignal, float threshold) {
+    static bool buzzerActive = false;
+    const int buzzerPin = 6;
+    const float HYSTERESIS_FACTOR = 0.85f;
+
+    float thresholdOn = threshold;
+    float thresholdOff = threshold * HYSTERESIS_FACTOR;
+    if (thresholdOff < 0.0f) {
+        thresholdOff = 0.0f;
     }
+
+    float signal = filteredSignal;
+    if (signal < 0.0f) {
+        signal = 0.0f;
+    }
+
+    if (buzzerActive) {
+        if (signal <= thresholdOff) {
+            noTone(buzzerPin);
+            buzzerActive = false;
+            return;
+        }
+    } else if (signal >= thresholdOn) {
+        buzzerActive = true;
+    } else {
+        noTone(buzzerPin);
+        return;
+    }
+
+    float normalized = signal - thresholdOff;
+    if (normalized < 0.0f) {
+        normalized = 0.0f;
+    }
+
+    int variaNote = constrain(static_cast<int>(normalized * 12.0f), 0, 48);
+    float tonal = tonalBase * pow(pitch, variaNote);
+    tone(buzzerPin, tonal, 120);
 }

--- a/src/buzzer.h
+++ b/src/buzzer.h
@@ -1,11 +1,12 @@
 /**
  * @file buzzer.h
- * @brief Generates audio feedback based on temperature variation.
+ * @brief Generates audio feedback based on the filtered thermal indicator.
  *
- * The buzzer emits tones whose pitch varies with the magnitude of the
- * temperature change.
+ * The buzzer emits tones when the smoothed thermal signal exceeds the user
+ * defined threshold. A small hysteresis prevents rapid toggling around the
+ * trigger point.
  */
 #pragma once
 
 void buzzerSetup();
-void buzzerUpdate(float tempDiff, float threshold);
+void buzzerUpdate(float filteredSignal, float threshold);


### PR DESCRIPTION
## Summary
- replace the 1 s blocking delay with a 150 ms sampling cadence that maintains a sliding window of temperature and pressure readings
- compute mean and standard deviation of per-metre slopes to derive a filtered thermal signal before driving the buzzer
- update the buzzer logic to use the filtered indicator with hysteresis to avoid chatter

## Testing
- not run (Arduino environment not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68caa34d739c832f83bbc454b9c5492c